### PR TITLE
Redo Literal Structure

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -19,7 +19,7 @@ pub enum Expr {
     LogExpr(LogExpr),
     LambdaExpr(LambdaExpr),
     Ident(Ident),
-    Literal(String),
+    Literal(Literal),
 }
 
 impl Into<Stmt> for Expr {
@@ -156,4 +156,23 @@ pub struct LambdaExpr {
     pub body: Block,
     #[new(value = r#""lambda_expr""#)]
     r#type: &'static str,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Clone, new)]
+pub struct Literal {
+    pub value: String,
+    #[new(value = r#""literal_expr""#)]
+    r#type: &'static str,
+}
+
+impl From<&str> for Literal {
+    fn from(string: &str) -> Literal {
+        Literal::new(string.into())
+    }
+}
+
+impl From<String> for Literal {
+    fn from(string: String) -> Literal {
+        Literal::new(string)
+    }
 }

--- a/src/lang/cpp/stmt.rs
+++ b/src/lang/cpp/stmt.rs
@@ -135,7 +135,8 @@ fn variable_init_declaration(init_declarator: &AST, mut variable_type: String) -
                     .map(|arg| expression(arg))
                     .flat_map(|arg| arg)
                     .collect();
-                let init = CallExpr::new(Box::new("new".to_string().into()), args).into();
+                let new: Literal = "new".to_string().into();
+                let init = CallExpr::new(Box::new(new.into()), args).into();
                 Some(init)
             }
             _ => None,
@@ -348,7 +349,7 @@ fn for_range_statement(for_range_loop: &AST) -> Option<ForRangeStmt> {
 
     // Convert generic node to statement
     let mut r#type = match r#type {
-        Some(Expr::Literal(t)) => t,
+        Some(Expr::Literal(t)) => t.value,
         Some(Expr::Ident(ident)) => ident.name,
         _ => "".into(),
     };

--- a/src/lang/java.rs
+++ b/src/lang/java.rs
@@ -449,7 +449,11 @@ fn parse_node(ast: &AST, component: &ComponentInfo) -> Option<Node> {
         | "decimal_floating_point_literal"
         | "string_literal"
         | "false"
-        | "true" => Some(Node::Expr(Expr::Literal(ast.value.clone()))),
+        | "true" => {
+            let literal: Literal = ast.value.clone().into();
+            let literal: Expr = literal.into();
+            Some(literal.into())
+        }
 
         "object_creation_expression" => {
             let mut name = String::new();


### PR DESCRIPTION
This was necessary because of the way Jackson in Java was trying to deserialize expressions, and particularly literals.