### PR TITLE
DeclStmt rework

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 #[derive(Debug, Eq, PartialEq, Serialize, Clone, From)]
 #[serde(untagged)]
 pub enum Expr {
+    AssignExpr(AssignExpr),
     BinaryExpr(BinaryExpr),
     UnaryExpr(UnaryExpr),
     CallExpr(CallExpr),
@@ -26,6 +27,14 @@ impl Into<Stmt> for Expr {
     fn into(self) -> Stmt {
         Stmt::ExprStmt(ExprStmt::new(self))
     }
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Clone, new)]
+pub struct AssignExpr {
+    pub lhs: Vec<Expr>,
+    pub rhs: Vec<Expr>,
+    #[new(value = r#""assign_expr""#)]
+    r#type: &'static str,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Clone, new)]

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -36,16 +36,24 @@ pub struct AssignStmt {
 
 #[derive(Debug, Eq, PartialEq, Serialize, Clone, new)]
 pub struct DeclStmt {
-    /// The type of the declared variable(s).
+    /// The declared variable(s).
+    pub variables: Vec<VarDecl>,
+    /// The expression(s) being assigned to the declared variables.
+    pub expressions: Vec<Expr>,
+    #[new(value = r#""decl_stmt""#)]
+    r#type: &'static str,
+}
+
+#[derive(Debug, Eq, PartialEq, Serialize, Clone, new)]
+pub struct VarDecl {
+    /// The type of the declared variable.
     pub var_type: Option<String>,
-    /// The variable(s). These could be Idents (x, y, z), BinExprs (x = y = 32) etc.
-    pub rhs: Vec<Expr>,
+    /// The variable(s).
+    pub ident: Ident,
     #[new(default)]
     pub is_static: Option<bool>,
     #[new(default)]
     pub is_final: Option<bool>,
-    #[new(value = r#""decl_stmt""#)]
-    r#type: &'static str,
 }
 
 #[derive(Debug, Eq, PartialEq, Serialize, Clone, From, new)]

--- a/src/ast/stmt.rs
+++ b/src/ast/stmt.rs
@@ -34,6 +34,16 @@ pub struct AssignStmt {
     r#type: &'static str,
 }
 
+/// For variable declaration statements, we can represent various situations for
+/// initialization.
+///
+/// In the example of Go variables may be delcared with a statement
+/// like `someVar, ok := os.Config("/path/to/file")` where we would represent this
+/// with two variables in the `variables` field, and one `CallExpr` in the `expressions`
+/// field.
+///
+/// For other declarations like `x, y := foo(), bar()`, we represent this just by
+/// having two variables and two call expressions in the respective `Vec` fields.
 #[derive(Debug, Eq, PartialEq, Serialize, Clone, new)]
 pub struct DeclStmt {
     /// The declared variable(s).

--- a/src/lang/cpp/expr.rs
+++ b/src/lang/cpp/expr.rs
@@ -217,11 +217,19 @@ fn binary_expression(node: &AST) -> Option<Expr> {
             log.args.push(rhs);
             return Some(log.into());
         }
-        _ => BinaryExpr::new(Box::new(lhs), op, Box::new(rhs)).into(),
+        _ => match op {
+            Op::Equal => AssignExpr::new(vec![lhs], vec![rhs]).into(),
+            _ => BinaryExpr::new(Box::new(lhs), op, Box::new(rhs)).into(),
+        },
     };
 
     if is_log {
-        let log = convert_binary_expr_to_log(expr)?;
+        // C++ logs should not be AssignExpr since they use the << operator
+        let binary_expr = match expr {
+            Expr::BinaryExpr(binary_expr) => binary_expr,
+            _ => unreachable!(),
+        };
+        let log = convert_binary_expr_to_log(binary_expr)?;
         Some(log.into())
     } else {
         Some(expr.into())

--- a/src/lang/cpp/stmt.rs
+++ b/src/lang/cpp/stmt.rs
@@ -703,10 +703,9 @@ mod tests {
             value: "".to_string(),
         };
 
-        let init: Expr = BinaryExpr::new(
-            Box::new(Ident::new("_i284".into()).into()),
-            Op::Equal,
-            Box::new(Expr::Literal("0".into())),
+        let init: Expr = AssignExpr::new(
+            vec![Ident::new("_i284".into()).into()],
+            vec![Expr::Literal("0".into())],
         )
         .into();
         let init: Stmt = init.into();

--- a/src/lang/java.rs
+++ b/src/lang/java.rs
@@ -394,9 +394,9 @@ fn parse_node(ast: &AST, component: &ComponentInfo) -> Option<Node> {
                 .collect();
 
             // TODO: Use name
-            let mut decl = DeclStmt::new(r#type, rhs);
-            decl.is_static = Some(modifier.is_static);
-            decl.is_final = Some(modifier.is_final);
+            let mut decl = DeclStmt::new(vec![], rhs);
+            // decl.is_static = Some(modifier.is_static);
+            // decl.is_final = Some(modifier.is_final);
             let decl: Stmt = decl.into();
             Some(decl.into())
         }


### PR DESCRIPTION
Reworked the DeclStmt structure so that we can support variable assignments from Go.

Inside of `VarDecl`, we may alternatively want to change the `ident` field to be an `Expr` like in the case of array declarations in C++, but so far I have separated them.