### PR TITLE
Add `new` derive to Directory structure for prophet2

### DIFF
--- a/src/parse.rs
+++ b/src/parse.rs
@@ -99,7 +99,7 @@ impl AST {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, new)]
 #[serde(rename_all = "camelCase")]
 pub struct Directory {
     files: Vec<PathBuf>,


### PR DESCRIPTION
We need to be able to create the `Directory` structure which we cannot currently do from `prophet2` when transforming cloned git repos into something that can be analyzed by this crate. Because of this, I've just gone ahead and added a `new` derive to `Directory` that we can call from there.