### PR TITLE
Bugfix add case expr

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -28,6 +28,7 @@ pub enum Expr {
     Ident(Ident),
     Literal(Literal),
     SwitchExpr(SwitchExpr),
+    CaseExpr(CaseExpr),
 }
 
 impl Expr {
@@ -49,6 +50,7 @@ impl Expr {
             Ident(e) => e.language,
             Literal(e) => e.language,
             SwitchExpr(e) => e.language,
+            CaseExpr(e) => e.language,
         }
     }
 }
@@ -250,8 +252,8 @@ impl From<SwitchExpr> for Stmt {
 
 #[derive(Debug, Eq, PartialEq, Serialize, Clone, new, NodeLanguage, ChildFields)]
 pub struct CaseExpr {
-    pub cond: Option<Expr>,
-    pub body: Block,
+    pub cond: Option<Box<Expr>>,
+    pub body: Box<Block>,
     #[new(value = r#""case_expr""#)]
     r#type: &'static str,
     pub language: Language,

--- a/src/lang/cpp/stmt.rs
+++ b/src/lang/cpp/stmt.rs
@@ -262,7 +262,7 @@ fn switch_case(case_statement: &AST) -> Option<CaseExpr> {
     }
     let nodes = block_nodes_iter(&case_statement.children[3..]);
     let block = Block::new(nodes, Cpp);
-    let case = CaseExpr::new(expr, block, Cpp);
+    let case = CaseExpr::new(expr.map(Box::new), Box::new(block), Cpp);
     Some(case)
 }
 

--- a/src/lang/java/method_body/expr.rs
+++ b/src/lang/java/method_body/expr.rs
@@ -288,14 +288,14 @@ pub(crate) fn parse_switch(ast: &AST, component: &ComponentInfo) -> Option<Expr>
 
     let gen_cases = |cases: &mut Vec<CaseExpr>, guard: &Option<Expr>, in_case: &Vec<&AST>| {
         cases.push(CaseExpr::new(
-            guard.clone(),
-            Block::new(
+            guard.clone().map(Box::new),
+            Box::new(Block::new(
                 in_case
                     .iter()
                     .flat_map(|c| parse_node(c, component))
                     .collect(),
                 Java,
-            ),
+            )),
             Java,
         ))
     };

--- a/src/ressa/explorer.rs
+++ b/src/ressa/explorer.rs
@@ -173,7 +173,7 @@ mod tests {
             Language::Unknown,
         )
         .into();
-        let mut np = NodePattern::new(
+        let np = NodePattern::new(
             NodeType::CallExpr,
             RefCell::new(None),
             RefCell::new(None),
@@ -187,6 +187,6 @@ mod tests {
         );
         let index = LaastIndex::new(HashMap::new(), HashMap::new());
         tracing::warn!("hello?");
-        c.explore(&mut np, &mut ExplorerContext::default(), &index);
+        c.explore(&np, &mut ExplorerContext::default(), &index);
     }
 }

--- a/src/ressa/mod.rs
+++ b/src/ressa/mod.rs
@@ -50,12 +50,12 @@ pub fn run_ressa_parse(ast: &mut Vec<ModuleComponent>, ressas: Vec<NodePattern>)
 
     // Explore
     let mut ctx = ExplorerContext::default();
-    for mut ressa in ressas.into_iter() {
+    for ressa in ressas.into_iter() {
         match ressa.language {
             // Wildcard language (apply to any language)
             Some(Language::Unknown) => {
                 for module in ast.iter() {
-                    module.explore(&mut ressa, &mut ctx, &project_index);
+                    module.explore(&ressa, &mut ctx, &project_index);
                 }
             }
 
@@ -63,7 +63,7 @@ pub fn run_ressa_parse(ast: &mut Vec<ModuleComponent>, ressas: Vec<NodePattern>)
                 // Apply to targeted language
                 if let Some(roots) = project_index.get_roots(ressa.get_language()) {
                     for module in roots.iter() {
-                        module.explore(&mut ressa, &mut ctx, &project_index);
+                        module.explore(&ressa, &mut ctx, &project_index);
                     }
                 }
             }

--- a/src/ressa/pattern_parser.rs
+++ b/src/ressa/pattern_parser.rs
@@ -186,12 +186,12 @@ impl NodePatternParser for MethodComponent {
         )?;
 
         // Match method parameters
-        let mut params = pattern
+        let params = pattern
             .subpatterns
             .iter()
             .filter(|child| matches!(child.identifier, crate::ressa::NodeType::MethodParam))
             .collect::<Vec<&NodePattern>>();
-        match_subsequence(&mut params, &self.parameters, ctx, index)?;
+        match_subsequence(&params, &self.parameters, ctx, index)?;
 
         // If there's a method body, explore it
         let mut tmp = vec![];
@@ -509,7 +509,7 @@ impl NodePatternParser for CallExpr {
         }
 
         // Match method parameters
-        let mut params = pattern
+        let params = pattern
             .subpatterns
             .iter()
             // .filter(|child| match child.identifier {
@@ -519,7 +519,7 @@ impl NodePatternParser for CallExpr {
             //     _ => false,
             // })
             .collect::<Vec<&NodePattern>>();
-        match_subsequence(&mut params, &self.args, ctx, index)
+        match_subsequence(&params, &self.args, ctx, index)
     }
 }
 


### PR DESCRIPTION
Expected that a CaseExpr would be an Expr variant. However, no such variant exists. Adds this variant.

Also repairs some Clippy linting that got missed at some point (extra `mut` tags).